### PR TITLE
bitmask passed to CreateBitmap was too small

### DIFF
--- a/src/windows/appw.c
+++ b/src/windows/appw.c
@@ -1363,8 +1363,8 @@ static void app_set_rgba_cursor(MTY_App *app, const uint8_t *rgba, uint32_t widt
 	ICONINFO ii = {0};
 	void *mask = NULL;
 
-	size_t pad = sizeof(size_t) * 8;
-	size_t mask_len = width + ((pad - width % pad) / 8) * height;
+	const size_t nPlanes = 1, nBitCount = 1;
+	const size_t mask_len = (((width * nPlanes * nBitCount + 15) >> 4) << 1) * height;
 	mask = MTY_Alloc(mask_len, 1);
 	memset(mask, 0xFF, mask_len);
 


### PR DESCRIPTION
size was calculated by "width + padding * height", should be "(width + padding) * height." this doesn't seem to have ever resulted in an error, though it would produce a bitmask that is far too small, in cases where width is large and padding is small.

new expression to calculate bitmask size in bytes, copied from https://learn.microsoft.com/en-us/windows/win32/api/wingdi/nf-wingdi-createbitmap