### PR TITLE
Add VID/PID for Xbox One S controller via Bluetooth on new firmware

### DIFF
--- a/src/hid/hid.c
+++ b/src/hid/hid.c
@@ -51,6 +51,7 @@ MTY_CType hid_driver(struct hid_dev *device)
 		case 0x045E02FD: // Microsoft X-Box One S pad (Bluetooth)
 		case 0x045E0B05: // Microsoft X-Box One Elite Series 2 pad (Bluetooth)
 		case 0x045E0B13: // Microsoft X-Box Series X (Bluetooth)
+		case 0x045E0B20: // Microsoft X-Box One S pad (Bluetooth)
 			return MTY_CTYPE_XBOX;
 
 		// Xbox Wired


### PR DESCRIPTION
Xbox One S gamepad on firmware 5.17.3202.0 presents VID/PID `045E/0B20`