### PR TITLE
Thread-local log disable function

### DIFF
--- a/src/log.c
+++ b/src/log.c
@@ -54,14 +54,10 @@ void MTY_SetLogFunc(MTY_LogFunc func, void *opaque)
 	LOG_OPAQUE = opaque;
 }
 
-void MTY_DisableLog(bool disabled)
+void MTY_DisableLog(uint8_t level)
 {
-	MTY_Atomic32Set(&LOG_DISABLED, disabled ? 1 : 0);
-}
-
-void MTY_DisableLogThread(bool disabled)
-{
-	LOG_DISABLED_THREAD = disabled;
+	MTY_Atomic32Set(&LOG_DISABLED, level & 0x1);
+	LOG_DISABLED_THREAD = level & 0x2;
 }
 
 void MTY_LogParams(const char *func, const char *fmt, ...)

--- a/src/log.c
+++ b/src/log.c
@@ -36,7 +36,7 @@ static void log_internal(const char *func, const char *fmt, va_list args)
 	MTY_Free(msg);
 	MTY_Free(fmt_name);
 
-	if (!MTY_Atomic32Get(&LOG_DISABLED) || LOG_DISABLED_THREAD) {
+	if (!LOG_DISABLED_THREAD && !MTY_Atomic32Get(&LOG_DISABLED)) {
 		LOG_PREVENT_RECURSIVE = true;
 		LOG_FUNC(LOG_MSG, LOG_OPAQUE);
 		LOG_PREVENT_RECURSIVE = false;

--- a/src/log.c
+++ b/src/log.c
@@ -17,6 +17,7 @@ static void *LOG_OPAQUE;
 
 static TLOCAL char *LOG_MSG;
 static TLOCAL bool LOG_PREVENT_RECURSIVE;
+static TLOCAL bool LOG_DISABLED_THREAD;
 
 static void log_none(const char *msg, void *opaque)
 {
@@ -35,7 +36,7 @@ static void log_internal(const char *func, const char *fmt, va_list args)
 	MTY_Free(msg);
 	MTY_Free(fmt_name);
 
-	if (!MTY_Atomic32Get(&LOG_DISABLED)) {
+	if (!MTY_Atomic32Get(&LOG_DISABLED) || LOG_DISABLED_THREAD) {
 		LOG_PREVENT_RECURSIVE = true;
 		LOG_FUNC(LOG_MSG, LOG_OPAQUE);
 		LOG_PREVENT_RECURSIVE = false;
@@ -56,6 +57,11 @@ void MTY_SetLogFunc(MTY_LogFunc func, void *opaque)
 void MTY_DisableLog(bool disabled)
 {
 	MTY_Atomic32Set(&LOG_DISABLED, disabled ? 1 : 0);
+}
+
+void MTY_DisableLogThread(bool disabled)
+{
+	LOG_DISABLED_THREAD = disabled;
 }
 
 void MTY_LogParams(const char *func, const char *fmt, ...)

--- a/src/matoya.h
+++ b/src/matoya.h
@@ -2194,6 +2194,11 @@ MTY_SetLogFunc(MTY_LogFunc func, void *opaque);
 MTY_EXPORT void
 MTY_DisableLog(bool disabled);
 
+/// @brief Temporarily disable logging in the current thread.
+/// @param disabled Specify true to disable logging, false to enable it.
+MTY_EXPORT void
+MTY_DisableLogThread(bool disabled);
+
 /// @brief Log a formatted string.
 /// @details This function is intended to be called internally via the
 ///   MTY_Log macro, but can be used to add to the libmatoya log.

--- a/src/matoya.h
+++ b/src/matoya.h
@@ -2190,8 +2190,6 @@ MTY_EXPORT void
 MTY_SetLogFunc(MTY_LogFunc func, void *opaque);
 
 /// @brief Temporarily disable logging.
-/// @details This prevents the calling of the log callback function,
-///   but you may still get the most recent log line via MTY_GetLog.
 /// @param level Bitwise OR of 0x1 to disable all logging and 0x2 to disable
 ///   logging on the current thread.
 MTY_EXPORT void

--- a/src/matoya.h
+++ b/src/matoya.h
@@ -2195,6 +2195,8 @@ MTY_EXPORT void
 MTY_DisableLog(bool disabled);
 
 /// @brief Temporarily disable logging in the current thread.
+/// @details This prevents the calling of the log callback function,
+///   but you may still get the most recent log line via MTY_GetLog.
 /// @param disabled Specify true to disable logging, false to enable it.
 MTY_EXPORT void
 MTY_DisableLogThread(bool disabled);

--- a/src/matoya.h
+++ b/src/matoya.h
@@ -2189,19 +2189,13 @@ MTY_GetLog(void);
 MTY_EXPORT void
 MTY_SetLogFunc(MTY_LogFunc func, void *opaque);
 
-/// @brief Temporarily disable all logging.
+/// @brief Temporarily disable logging.
 /// @details This prevents the calling of the log callback function,
 ///   but you may still get the most recent log line via MTY_GetLog.
-/// @param disabled Specify true to disable logging, false to enable it.
+/// @param level Bitwise OR of 0x1 to disable all logging and 0x2 to disable
+///   logging on the current thread.
 MTY_EXPORT void
-MTY_DisableLog(bool disabled);
-
-/// @brief Temporarily disable logging in the current thread.
-/// @details This prevents the calling of the log callback function,
-///   but you may still get the most recent log line via MTY_GetLog.
-/// @param disabled Specify true to disable logging, false to enable it.
-MTY_EXPORT void
-MTY_DisableLogThread(bool disabled);
+MTY_DisableLog(uint8_t level);
 
 /// @brief Log a formatted string.
 /// @details This function is intended to be called internally via the

--- a/src/matoya.h
+++ b/src/matoya.h
@@ -2190,6 +2190,8 @@ MTY_EXPORT void
 MTY_SetLogFunc(MTY_LogFunc func, void *opaque);
 
 /// @brief Temporarily disable all logging.
+/// @details This prevents the calling of the log callback function,
+///   but you may still get the most recent log line via MTY_GetLog.
 /// @param disabled Specify true to disable logging, false to enable it.
 MTY_EXPORT void
 MTY_DisableLog(bool disabled);


### PR DESCRIPTION
Provides `MTY_DisableLogThread` to allow for disabling logging on a single thread.

Useful if your log callback feeds into a dedicated logging thread (that you don't want recursively logging), or to configure application logging on a per-thread basis.

Currently we try to use `MTY_DisableLog` for this, but it runs the risk of dropping logging from other threads in the period the logging is disabled.