### PR TITLE
[WASM] Fix unrecognized gamepads

### DIFF
--- a/src/unix/web/matoya.js
+++ b/src/unix/web/matoya.js
@@ -563,7 +563,7 @@ function mty_rumble_gamepad(id, low, high) {
 		});
 }
 
-function mty_poll_gamepads() {
+function mty_poll_gamepads(thread) {
 	const gps = navigator.getGamepads();
 
 	for (let x = 0; x < 4; x++) {
@@ -781,7 +781,7 @@ function mty_supports_web_gl() {
 function mty_update_interval(thread) {
 	// Poll gamepads
 	if (document.hasFocus())
-		mty_poll_gamepads();
+		mty_poll_gamepads(thread);
 
 	// Poll position changes
 	if (MTY.posX != window.screenX || MTY.posY != window.screenY) {


### PR DESCRIPTION
Diff is self-explanatory, `thread` was undefined in `mty_poll_gamepads` and needed to be passed from `mty_update_interval`.