### PR TITLE
WASM WebSocket Keepalive

### DIFF
--- a/src/unix/web/matoya.js
+++ b/src/unix/web/matoya.js
@@ -744,14 +744,12 @@ async function mty_ws_connect(url) {
 
 		ws.onopen = () => {
 			resolve(ws);
-			setInterval(() => {ws.send('__ping__');}, 5000); // 5 second ping to debug before PR
+			setInterval(() => {ws.send('__ping__');}, 60000); // Blind keepalive
 		};
 
 		ws.onmessage = (ev) => {
-			if (ws.data == '__pong__') {
-				console.log("pong")
-				return;
-			}
+			if (ws.data == '__pong__')
+				return; // Hide keepalive pong from client application
 
 			ws.msgs.push(ev.data);
 			Atomics.notify(ws.sync, 0, 1);

--- a/src/unix/web/matoya.js
+++ b/src/unix/web/matoya.js
@@ -744,9 +744,15 @@ async function mty_ws_connect(url) {
 
 		ws.onopen = () => {
 			resolve(ws);
+			setInterval(() => {ws.send('__ping__');}, 5000); // 5 second ping to debug before PR
 		};
 
 		ws.onmessage = (ev) => {
+			if (ws.data == '__pong__') {
+				console.log("pong")
+				return;
+			}
+
 			ws.msgs.push(ev.data);
 			Atomics.notify(ws.sync, 0, 1);
 		};

--- a/src/unix/web/matoya.js
+++ b/src/unix/web/matoya.js
@@ -751,6 +751,11 @@ async function mty_ws_connect(url) {
 			if (ws.data == '__pong__')
 				return; // Hide keepalive pong from client application
 
+			if (ws.data == '__ping__') {
+				ws.send('__pong__');
+				return; // Reply to keepalive ping
+			}
+
 			ws.msgs.push(ev.data);
 			Atomics.notify(ws.sync, 0, 1);
 		};

--- a/src/unix/web/matoya.js
+++ b/src/unix/web/matoya.js
@@ -732,19 +732,22 @@ async function mty_ws_connect(url) {
 		ws.closeCode = 0;
 		ws.msgs = [];
 
+		let tm = 0;
 		ws.onclose = (ev) => {
 			ws.closeCode = ev.code == 1005 ? 1000 : ev.code;
+			clearInterval(tm);
 			resolve(null);
 		};
 
 		ws.onerror = (err) => {
 			console.error(err);
+			clearInterval(tm);
 			resolve(null);
 		};
 
 		ws.onopen = () => {
 			resolve(ws);
-			setInterval(() => {ws.send('__ping__');}, 60000); // Fake keepalive
+			tm = setInterval(() => {ws.send('__ping__');}, 60000); // Fake keepalive
 		};
 
 		ws.onmessage = (ev) => {

--- a/src/unix/web/matoya.js
+++ b/src/unix/web/matoya.js
@@ -744,18 +744,10 @@ async function mty_ws_connect(url) {
 
 		ws.onopen = () => {
 			resolve(ws);
-			setInterval(() => {ws.send('__ping__');}, 60000); // Blind keepalive
+			setInterval(() => {ws.send('__ping__');}, 60000); // Fake keepalive
 		};
 
 		ws.onmessage = (ev) => {
-			if (ws.data == '__pong__')
-				return; // Hide keepalive pong from client application
-
-			if (ws.data == '__ping__') {
-				ws.send('__pong__');
-				return; // Reply to keepalive ping
-			}
-
 			ws.msgs.push(ev.data);
 			Atomics.notify(ws.sync, 0, 1);
 		};


### PR DESCRIPTION
Sends a fake `__ping__` keepalive every 60 seconds.

Client-side javascript cannot send ping or pong command frames, this is a fake keepalive that prevents AWS and Cloudflare from considering the WebSocket to be idle and terminating it.