### PR TITLE
Add MTY_AppSetCursorSize

### DIFF
--- a/src/matoya.h
+++ b/src/matoya.h
@@ -856,12 +856,25 @@ MTY_AppSetPNGCursor(MTY_App *ctx, const void *image, size_t size, uint32_t hotX,
 
 /// @brief Use a cursor predefined by the OS.
 /// @details The cursor set via this function will take precedence over any set with
-///   MTY_AppSetPNGCursor.
+///   MTY_AppSetPNGCursor or MTY_AppSetRGBACursor.
 /// @param ctx The MTY_App.
 /// @param cursor The predefined cursor. Set MTY_CURSOR_NONE to revert the effects
 ///   of this function.
 MTY_EXPORT void
 MTY_AppSetCursor(MTY_App *ctx, MTY_Cursor cursor);
+
+/// @brief Set the cursor magnification scale for new cursors.
+/// @details On platforms that support cursor magnification, this tells
+///   libmatoya that whenever new cursors are set with MTY_AppSetRGBACursor or
+///   MTY_AppSetPNGCursor, the provided cursor bitmaps are assumed to be
+///   the specified width and height, rather than the pixel size of the buffer
+///   passed to the function.
+/// @param ctx The MTY_App.
+/// @param width The width that the cursor should be displayed at, in pixels
+/// @param height The height that the cursor should be displayed at, in pixels
+//- #support macOS
+MTY_EXPORT void
+MTY_AppSetCursorSize(MTY_App *ctx, uint32_t width, uint32_t height);
 
 /// @brief Show or hide the cursor.
 /// @param ctx The MTY_App.

--- a/src/unix/apple/macosx/app.m
+++ b/src/unix/apple/macosx/app.m
@@ -34,6 +34,8 @@ struct MTY_App {
 	NSObject <NSApplicationDelegate, NSUserNotificationCenterDelegate> *nsapp;
 	NSCursor *custom_cursor;
 	NSCursor *cursor;
+	uint32_t cursor_width;
+	uint32_t cursor_height;
 	IOPMAssertionID assertion;
 	MTY_AppFunc app_func;
 	MTY_EventFunc event_func;
@@ -1339,6 +1341,8 @@ MTY_App *MTY_AppCreate(MTY_AppFlag flags, MTY_AppFunc appFunc, MTY_EventFunc eve
 	ctx->opaque = opaque;
 	ctx->cursor_showing = true;
 	ctx->cont = true;
+	ctx->cursor_width = 0;
+	ctx->cursor_height = 0;
 
 	ctx->hid = mty_hid_create(app_hid_connect, app_hid_disconnect, app_hid_report,
 		ctx->flags & MTY_APP_FLAG_HID_KEYBOARD ? app_hid_key : NULL, ctx);
@@ -1517,6 +1521,18 @@ static void app_set_cursor(MTY_App *ctx, NSImage *image, uint32_t hotX, uint32_t
 	app_apply_cursor(ctx);
 }
 
+// @brief Descales the rendered dimensions of the given NSImage (without resizing the pixel array).
+static void app_descale_nsimage(NSImage *nsi, uint32_t width, uint32_t height)
+{
+	if (!nsi || [[nsi representations] count] < 1 || width == 0 || height == 0)
+		return;
+
+	NSSize csize = [nsi size];
+	csize.width = width;
+	csize.height = height;
+	nsi.size = csize;
+}
+
 void MTY_AppSetRGBACursor(MTY_App *ctx, const void *image, uint32_t width, uint32_t height,
 	uint32_t hotX, uint32_t hotY)
 {
@@ -1530,8 +1546,10 @@ void MTY_AppSetRGBACursor(MTY_App *ctx, const void *image, uint32_t width, uint3
 			hasAlpha:YES isPlanar:NO colorSpaceName:NSDeviceRGBColorSpace
 			bytesPerRow:width * 4 bitsPerPixel:32];
 
-		if (rep)
+		if (rep) {
 			nsi = [[NSImage alloc] initWithCGImage:rep.CGImage size:NSZeroSize];
+			app_descale_nsimage(nsi, ctx->cursor_width, ctx->cursor_height);
+		}
 	}
 
 	app_set_cursor(ctx, nsi, hotX, hotY);
@@ -1541,6 +1559,7 @@ void MTY_AppSetPNGCursor(MTY_App *ctx, const void *image, size_t size, uint32_t 
 {
 	NSImage *nsi = image ? [[NSImage alloc] initWithData:[NSData dataWithBytes:image length:size]] : nil;
 
+	app_descale_nsimage(nsi, ctx->cursor_width, ctx->cursor_height);
 	app_set_cursor(ctx, nsi, hotX, hotY);
 }
 
@@ -1549,6 +1568,12 @@ void MTY_AppSetCursor(MTY_App *ctx, MTY_Cursor cursor)
 	ctx->scursor = cursor;
 
 	app_apply_cursor(ctx);
+}
+
+void MTY_AppSetCursorSize(MTY_App *ctx, uint32_t width, uint32_t height)
+{
+	ctx->cursor_width = width;
+	ctx->cursor_height = height;
 }
 
 void MTY_AppShowCursor(MTY_App *ctx, bool show)

--- a/src/unix/linux/android/app.c
+++ b/src/unix/linux/android/app.c
@@ -861,6 +861,10 @@ void MTY_AppSetCursor(MTY_App *ctx, MTY_Cursor cursor)
 	mty_jni_void(MTY_GetJNIEnv(), ctx->obj, "useDefaultCursor", "(Z)V", cursor != MTY_CURSOR_NONE);
 }
 
+void MTY_AppSetCursorSize(MTY_App* ctx, uint32_t width, uint32_t height)
+{
+}
+
 void MTY_AppShowCursor(MTY_App *ctx, bool show)
 {
 	mty_jni_void(MTY_GetJNIEnv(), ctx->obj, "showCursor", "(Z)V", show);

--- a/src/unix/linux/x11/app.c
+++ b/src/unix/linux/x11/app.c
@@ -959,6 +959,10 @@ void MTY_AppSetCursor(MTY_App *ctx, MTY_Cursor cursor)
 	}
 }
 
+void MTY_AppSetCursorSize(MTY_App* ctx, uint32_t width, uint32_t height)
+{
+}
+
 void MTY_AppShowCursor(MTY_App *ctx, bool show)
 {
 	if (ctx->hide_cursor == show) {

--- a/src/unix/web/app.c
+++ b/src/unix/web/app.c
@@ -428,6 +428,10 @@ void MTY_AppSetCursor(MTY_App *ctx, MTY_Cursor cursor)
 	web_use_default_cursor(cursor != MTY_CURSOR_NONE);
 }
 
+void MTY_AppSetCursorSize(MTY_App* ctx, uint32_t width, uint32_t height)
+{
+}
+
 void MTY_AppShowCursor(MTY_App *ctx, bool show)
 {
 	web_show_cursor(show);

--- a/src/windows/appw.c
+++ b/src/windows/appw.c
@@ -1465,6 +1465,10 @@ void MTY_AppSetCursor(MTY_App *ctx, MTY_Cursor cursor)
 	}
 }
 
+void MTY_AppSetCursorSize(MTY_App* ctx, uint32_t width, uint32_t height)
+{
+}
+
 void MTY_AppShowCursor(MTY_App *ctx, bool show)
 {
 	if (ctx->hide_cursor == show) {


### PR DESCRIPTION
Set the cursor magnification scale for new cursors.

On platforms that support cursor magnification, this tells libmatoya that whenever new cursors are set with MTY_AppSetRGBACursor or MTY_AppSetPNGCursor, the provided cursor bitmaps are assumed to be the specified width and height, rather than the pixel size of the buffer passed to the function.