### PR TITLE
Fix Android audio infinite flushing

### DIFF
--- a/src/unix/linux/android/audio.c
+++ b/src/unix/linux/android/audio.c
@@ -155,7 +155,7 @@ void MTY_AudioQueue(MTY_Audio *ctx, const int16_t *frames, uint32_t count)
 		ctx->size = 0;
 	}
 
-	if (ctx->size == 0)
+	if (ctx->size == 0) {
 		ctx->playing = false;
 		ctx->flushing = false;
 	}

--- a/src/unix/linux/android/audio.c
+++ b/src/unix/linux/android/audio.c
@@ -150,9 +150,12 @@ void MTY_AudioQueue(MTY_Audio *ctx, const int16_t *frames, uint32_t count)
 		ctx->flushing = true;
 
 	size_t minimum_request = AAudioStream_getFramesPerBurst(ctx->stream) * ctx->channels * AUDIO_SAMPLE_SIZE;
-	if (ctx->size < minimum_request) {
+	if (ctx->flushing && ctx->size < minimum_request) {
 		memset(ctx->buffer, 0, ctx->size);
 		ctx->size = 0;
+	}
+
+	if (ctx->size == 0)
 		ctx->playing = false;
 		ctx->flushing = false;
 	}

--- a/src/unix/linux/android/audio.c
+++ b/src/unix/linux/android/audio.c
@@ -149,7 +149,10 @@ void MTY_AudioQueue(MTY_Audio *ctx, const int16_t *frames, uint32_t count)
 	if (ctx->size + data_size >= ctx->max_buffer)
 		ctx->flushing = true;
 
-	if (ctx->size == 0) {
+	size_t minimum_request = AAudioStream_getFramesPerBurst(ctx->stream) * ctx->channels * AUDIO_SAMPLE_SIZE;
+	if (ctx->size < minimum_request) {
+		memset(ctx->buffer, 0, ctx->size);
+		ctx->size = 0;
 		ctx->playing = false;
 		ctx->flushing = false;
 	}


### PR DESCRIPTION
The Android audio callback will never request a number of frames smaller than the return value of `AAudioStream_getFramesPerBurst`.

If the audio buffer is flushing, but has less data than Android will ever request, then the buffer never empties and never stops trying to flush.

Instead, libmatoya should discard any frames below the what can be requested.